### PR TITLE
Add explicit conversion operator support

### DIFF
--- a/BreakInfinity/BigDouble.cs
+++ b/BreakInfinity/BigDouble.cs
@@ -423,6 +423,11 @@ namespace BreakInfinity
             return new BigDouble(value);
         }
 
+        public static explicit operator double(BigDouble value)
+        {
+            return value.ToDouble();
+        }
+
         public static BigDouble operator -(BigDouble value)
         {
             return Negate(value);


### PR DESCRIPTION
And all of that is in 4 lines!
```c#
BigDouble a = 1e100;
double b = (double)a;
Console.WriteLine(b) // 1E+100
```